### PR TITLE
Fix crash: replace RenderTexture with Html for monitor screens

### DIFF
--- a/3D_portfolio/src/models/RoomScene.jsx
+++ b/3D_portfolio/src/models/RoomScene.jsx
@@ -1,39 +1,70 @@
 import React, { useMemo } from "react";
-import { useGLTF, RenderTexture } from "@react-three/drei";
+import { useGLTF, Html } from "@react-three/drei";
 import * as THREE from "three";
 import FakeOSDesktop from "../components/FakeOSDesktop";
 import EmulatorV86 from "../components/EmulatorV86";
 
-// Map node names (must match Blender names exactly) → screen content type
-// Verified node names from timeshot-room2.glb:
-//   "large monitor screen"  → large display (emulator / future project showcase)
-//   "small monitor screen"  → small display (FakeOS portfolio)
+// Map node names (verified from timeshot-room2.glb) → content type
 const SCREEN_MAP = {
-  "large monitor screen": "route",
-  "small monitor screen": "fakeOS",
+  "large monitor screen": "route",   // emulator / future project page
+  "small monitor screen": "fakeOS",  // FakeOS portfolio
 };
 
-// Renders a screen mesh with its original geometry but a live RenderTexture material.
-// The original mesh is hidden in the parent clone; this one replaces it visually.
-function ScreenMesh({ mesh, type }) {
-  const { position, quaternion, scale } = useMemo(() => {
+// ─────────────────────────────────────────────────────────────────────────────
+// WHY Html INSTEAD OF RenderTexture:
+// RenderTexture uses R3F's own fiber reconciler as its rendering context.
+// Any HTML element (<button>, <div>, <a> …) passed as its children causes
+// R3F to look for THREE.Button / THREE.Div / etc., which don't exist →
+// "not part of the THREE namespace" crash + WebGL context loss.
+//
+// drei's <Html transform> renders real DOM nodes positioned in 3D space via
+// CSS transform3d — completely outside the Three.js reconciler — so all
+// standard React/DOM/Tailwind content works as normal.
+// ─────────────────────────────────────────────────────────────────────────────
+function ScreenHtml({ mesh, type }) {
+  const { center, euler, cssW, cssH, pixelScale } = useMemo(() => {
     mesh.updateWorldMatrix(true, false);
-    const pos  = new THREE.Vector3();
+
+    // World-space AABB → center position + physical dimensions
+    const bbox = new THREE.Box3().setFromObject(mesh);
+    const center = new THREE.Vector3();
+    bbox.getCenter(center);
+    const size = bbox.getSize(new THREE.Vector3());
+
+    // World-space rotation (for Html to face the same direction as the screen)
     const quat = new THREE.Quaternion();
-    const scl  = new THREE.Vector3();
-    mesh.matrixWorld.decompose(pos, quat, scl);
-    return { position: pos, quaternion: quat, scale: scl };
+    const tmp  = new THREE.Vector3();
+    mesh.matrixWorld.decompose(tmp, quat, new THREE.Vector3());
+    const euler = new THREE.Euler().setFromQuaternion(quat, 'YXZ');
+
+    // Map world units → CSS pixels.
+    // We render at 512px wide; scale prop makes 512 CSS px = size.x world units.
+    const cssW = 512;
+    const cssH = Math.round((size.y / Math.max(size.x, 0.001)) * cssW);
+    const pixelScale = size.x / cssW;
+
+    return { center, euler, cssW, cssH, pixelScale };
   }, [mesh]);
 
   return (
-    <mesh geometry={mesh.geometry} position={position} quaternion={quaternion} scale={scale}>
-      <meshBasicMaterial toneMapped={false}>
-        <RenderTexture attach="map" width={1024} height={768}>
-          {type === "fakeOS" && <FakeOSDesktop />}
-          {type === "route" && <EmulatorV86 />}
-        </RenderTexture>
-      </meshBasicMaterial>
-    </mesh>
+    <Html
+      transform
+      position={center}
+      rotation={euler}
+      scale={pixelScale}
+      zIndexRange={[1, 0]}
+      style={{
+        width:    cssW,
+        height:   cssH,
+        overflow: 'hidden',
+        background: '#000',
+        pointerEvents: 'auto',
+        userSelect: 'none',
+      }}
+    >
+      {type === "fakeOS" && <FakeOSDesktop />}
+      {type === "route"  && <EmulatorV86 />}
+    </Html>
   );
 }
 
@@ -41,13 +72,12 @@ export default function RoomScene() {
   const { scene } = useGLTF("/models/timeshot-room2.glb");
   const cloned = useMemo(() => scene.clone(true), [scene]);
 
-  // Find screen meshes, hide originals so ScreenMesh can take over
   const screens = useMemo(() => {
     const result = [];
     Object.entries(SCREEN_MAP).forEach(([name, type]) => {
       const mesh = cloned.getObjectByName(name);
       if (mesh?.isMesh) {
-        mesh.visible = false; // hidden — ScreenMesh renders it instead
+        mesh.visible = false; // Html overlay replaces this mesh visually
         result.push({ mesh, type });
       }
     });
@@ -58,7 +88,7 @@ export default function RoomScene() {
     <>
       <primitive object={cloned} />
       {screens.map(({ mesh, type }) => (
-        <ScreenMesh key={mesh.uuid} mesh={mesh} type={type} />
+        <ScreenHtml key={mesh.uuid} mesh={mesh} type={type} />
       ))}
     </>
   );


### PR DESCRIPTION
RenderTexture uses R3F's fiber reconciler internally. Any HTML element (<button>, <div>, <a>) passed as its children causes R3F to look up THREE.Button / THREE.Div etc., which don't exist, triggering:
  "Button is not part of the THREE namespace"
followed by WebGL context loss.

Replace ScreenMesh+RenderTexture with ScreenHtml using drei's <Html transform>. Html renders real DOM nodes via CSS transform3d, completely outside the Three.js reconciler, so FakeOSDesktop and EmulatorV86 (with all their Tailwind/button/div content) work correctly.

World-space center + rotation are extracted from mesh.matrixWorld so the Html overlay is precisely positioned and rotated to match each screen mesh. pixelScale maps 512 CSS pixels to the physical screen width in world units.