### PR TITLE
Fix R3F Button-in-THREE crash and 404, split DOM HUDs out of Canvas

### DIFF
--- a/3D_portfolio/CLAUDE.md
+++ b/3D_portfolio/CLAUDE.md
@@ -1,0 +1,75 @@
+# 3D Portfolio — Claude Context
+
+## Project
+React Three Fiber 3D portfolio. Interactive room scene with VTuber desktop companion, monitor screens, first-person camera, and mobile touch controls.
+
+## Stack
+- **React 19** + **Vite 6**
+- **@react-three/fiber v9** + **@react-three/drei v10** + **Three.js 0.177**
+- **@pixiv/three-vrm v3** for VTuber model
+- **Tailwind v4** (PostCSS plugin: `@tailwindcss/postcss`)
+
+## Key Architecture Rules
+
+### R3F DOM Rendering — CRITICAL
+**Never render HTML elements (`<button>`, `<div>`, etc.) inside `<Canvas>` directly.**
+R3F's custom reconciler maps JSX tags to `THREE.*` objects — `<button>` → looks for `THREE.Button` → crashes.
+
+Safe patterns inside Canvas:
+- `<Html transform>` from `@react-three/drei` — renders real DOM via CSS transform in 3D space (used for monitor screens)
+- Three.js primitives only: `<mesh>`, `<primitive>`, `<ambientLight>`, etc.
+
+DOM overlays (HUDs, buttons, panels) must be **outside** `<Canvas>` in `App.jsx` and rendered as normal React DOM components.
+
+### Component Layout (App.jsx)
+```
+<Canvas>          ← Three.js only
+  <RoomScene />   ← uses <Html> for monitor screens
+  <VTuberView />  ← pure Three.js
+  <FreeCameraControls mode setMode plcLockRef />   ← Three.js logic only
+  <MobileControls mode setMode />                  ← Three.js logic only
+</Canvas>
+
+<CameraHUD mode setMode plcLockRef />   ← DOM HUD, outside Canvas
+<MobileHUD mode setMode />              ← DOM HUD, outside Canvas
+```
+
+### Camera State
+`cameraMode` state lives in `App.jsx` (`'preset' | 'confirming' | 'free'`) and is passed as props to both the Canvas component (for useFrame logic) and the DOM HUD (for rendering).
+
+`plcLockRef` — ref set by `FreeCameraControls` to expose `PointerLockControls.lock()` to `CameraHUD`.
+
+### Shared Mobile State (module-level in MobileControls.jsx)
+```js
+move, look           // joystick deltas, written by touch handlers, read by useFrame
+mobilePresetTarget, mobileLerpingRef, mobileTargetQuat  // shared between MobileHUD (goToPreset) and MobileControls (useFrame)
+```
+
+## Public Assets
+```
+public/
+  models/      timeshot-room2.glb, VTuber2.vrm
+  hdr/         environment maps
+  music/       background audio
+  v86/
+    libv86.js, v86.wasm
+    bios/  seabios.bin, vgabios.bin
+    images/ TinyCore-current.iso   ← exact filename (not tinycore.iso)
+```
+
+## File Map
+```
+src/
+  App.jsx                          entry, camera state lives here
+  models/RoomScene.jsx             room GLB + Html screen overlays
+  components/
+    FreeCameraControls.jsx         Three.js WASD + PointerLock (Canvas only)
+    CameraHUD.jsx                  desktop HUD DOM (outside Canvas)
+    MobileControls.jsx             Three.js touch camera (Canvas only)
+    MobileHUD.jsx                  mobile overlay DOM (outside Canvas)
+    VTuberView.jsx                 VRM model + idle animation
+    FakeOSDesktop.jsx              fake OS UI rendered on monitor via Html
+    EmulatorV86.jsx                v86 emulator on large monitor
+    BackgroundMusic.jsx
+    Loader.jsx
+```

--- a/3D_portfolio/src/App.jsx
+++ b/3D_portfolio/src/App.jsx
@@ -1,5 +1,5 @@
 import { Canvas } from '@react-three/fiber';
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useRef } from 'react';
 import { useProgress, useGLTF } from '@react-three/drei';
 import RoomScene from './models/RoomScene';
 import VTuberView from './components/VTuberView';
@@ -8,20 +8,24 @@ import BackgroundMusic from './components/BackgroundMusic';
 import Loader from './components/Loader';
 import FreeCameraControls from './components/FreeCameraControls';
 import MobileControls from './components/MobileControls';
-
+import CameraHUD from './components/CameraHUD';
+import MobileHUD from './components/MobileHUD';
 
 useGLTF.preload('/models/VTuber2.vrm');
 
 export default function App() {
   const { progress } = useProgress();
-  const [showLoader, setShowLoader] = useState(true);
+  const [showLoader, setShowLoader]   = useState(true);
   const [sceneVisible, setSceneVisible] = useState(false);
-  const [playMusic, setPlayMusic] = useState(false);
+  const [playMusic, setPlayMusic]     = useState(false);
+
+  // Camera mode owned here so HUDs (outside Canvas) and controls (inside Canvas) share it
+  const [cameraMode, setCameraMode] = useState('preset');
+  const plcLockRef = useRef(null); // set by FreeCameraControls, called by CameraHUD
 
   const handleEnter = () => {
     const loaderEl = document.getElementById('loading-overlay');
     if (loaderEl) loaderEl.classList.add('fade-out');
-
     setTimeout(() => {
       setShowLoader(false);
       setSceneVisible(true);
@@ -31,10 +35,7 @@ export default function App() {
 
   return (
     <>
-      {showLoader && (
-        <Loader progress={progress} onEnter={handleEnter} />
-      )}
-
+      {showLoader && <Loader progress={progress} onEnter={handleEnter} />}
       {playMusic && <BackgroundMusic />}
 
       <Canvas
@@ -56,9 +57,35 @@ export default function App() {
           </Suspense>
         )}
 
-        {sceneVisible && <FreeCameraControls />}
-        {sceneVisible && <MobileControls />}
+        {sceneVisible && (
+          <FreeCameraControls
+            mode={cameraMode}
+            setMode={setCameraMode}
+            plcLockRef={plcLockRef}
+          />
+        )}
+        {sceneVisible && (
+          <MobileControls
+            mode={cameraMode}
+            setMode={setCameraMode}
+          />
+        )}
       </Canvas>
+
+      {/* HUDs rendered outside Canvas — safe DOM territory */}
+      {sceneVisible && (
+        <CameraHUD
+          mode={cameraMode}
+          setMode={setCameraMode}
+          plcLockRef={plcLockRef}
+        />
+      )}
+      {sceneVisible && (
+        <MobileHUD
+          mode={cameraMode}
+          setMode={setCameraMode}
+        />
+      )}
     </>
   );
 }

--- a/3D_portfolio/src/components/CameraHUD.jsx
+++ b/3D_portfolio/src/components/CameraHUD.jsx
@@ -1,0 +1,142 @@
+// src/components/CameraHUD.jsx
+// Desktop camera HUD — rendered OUTSIDE <Canvas> in App.jsx as a normal DOM component.
+// No createPortal needed here; position:fixed handles layering.
+import { CAMERA_PRESETS } from './FreeCameraControls';
+
+const kbdStyle = {
+  background: '#1e293b', border: '1px solid #334155',
+  borderRadius: 4, padding: '1px 6px', fontSize: 11,
+  fontFamily: 'monospace', color: '#e2e8f0',
+};
+const btnBase = {
+  border: 'none', cursor: 'pointer', borderRadius: 8,
+  fontFamily: 'system-ui, sans-serif', fontWeight: 500,
+};
+const btnPrimary = {
+  ...btnBase, flex: 1,
+  background: '#3b82f6', color: '#fff',
+  padding: '9px 16px', fontSize: 13,
+};
+const btnSecondary = {
+  ...btnBase,
+  background: 'rgba(255,255,255,0.08)', color: '#94a3b8',
+  border: '1px solid rgba(255,255,255,0.12)',
+  padding: '7px 14px', fontSize: 12,
+};
+const btnPreset = {
+  ...btnBase,
+  background: 'rgba(15,23,42,0.85)', color: '#e2e8f0',
+  border: '1px solid rgba(255,255,255,0.15)',
+  backdropFilter: 'blur(8px)',
+  padding: '8px 16px', fontSize: 12,
+};
+const btnUnlock = {
+  ...btnBase,
+  background: 'rgba(59,130,246,0.15)', color: '#93c5fd',
+  border: '1px solid rgba(59,130,246,0.3)',
+  backdropFilter: 'blur(8px)',
+  padding: '8px 16px', fontSize: 12,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Props:
+//   mode        — 'preset' | 'confirming' | 'free'
+//   setMode     — setter from App
+//   plcLockRef  — ref set by FreeCameraControls; call .current() to lock pointer
+// ─────────────────────────────────────────────────────────────────────────────
+export default function CameraHUD({ mode, setMode, plcLockRef }) {
+  const confirmFree = () => {
+    setMode('free');
+    setTimeout(() => plcLockRef.current?.(), 150);
+  };
+
+  // ── Confirmation overlay ──
+  if (mode === 'confirming') {
+    return (
+      <div style={{
+        position: 'fixed', inset: 0,
+        background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(4px)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 10000,
+      }}>
+        <div style={{
+          background: '#0f172a', border: '1px solid rgba(255,255,255,0.15)',
+          borderRadius: 12, padding: '28px 32px', maxWidth: 380, width: '90vw',
+          color: '#fff', fontFamily: 'system-ui, sans-serif',
+          boxShadow: '0 25px 60px rgba(0,0,0,0.6)',
+        }}>
+          <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 8 }}>
+            🔓 Enable Free Camera?
+          </div>
+          <div style={{ fontSize: 13, color: '#94a3b8', lineHeight: 1.6, marginBottom: 20 }}>
+            This will lock your mouse cursor to the window for first-person exploration.
+          </div>
+          <div style={{
+            background: '#1e293b', borderRadius: 8, padding: '12px 16px',
+            marginBottom: 20, fontSize: 12, color: '#cbd5e1', lineHeight: 2,
+          }}>
+            <div><kbd style={kbdStyle}>W A S D</kbd> &nbsp;Move</div>
+            <div><kbd style={kbdStyle}>Mouse</kbd> &nbsp;Look around</div>
+            <div><kbd style={kbdStyle}>Space</kbd> / <kbd style={kbdStyle}>Ctrl</kbd> &nbsp;Up / Down</div>
+            <div><kbd style={kbdStyle}>Shift</kbd> &nbsp;Sprint</div>
+            <div><kbd style={kbdStyle}>Esc</kbd> &nbsp;Exit free camera</div>
+          </div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button onClick={() => setMode('preset')} style={btnSecondary}>Cancel</button>
+            <button onClick={confirmFree}             style={btnPrimary}>Enter Free Camera</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Free camera banner + exit button ──
+  if (mode === 'free') {
+    return (
+      <div style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0,
+        background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(8px)',
+        borderTop: '1px solid rgba(255,255,255,0.1)',
+        padding: '8px 16px',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        zIndex: 9999, fontFamily: 'system-ui, sans-serif',
+        flexWrap: 'wrap', gap: 8,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+          <span style={{ color: '#64748b', fontSize: 11 }}>FREE CAMERA</span>
+          {[
+            ['W A S D', 'Move'], ['Mouse', 'Look'],
+            ['Space / Ctrl', 'Up / Down'], ['Shift', 'Sprint'], ['Esc', 'Exit'],
+          ].map(([key, label]) => (
+            <span key={key} style={{ fontSize: 11, color: '#94a3b8' }}>
+              <kbd style={kbdStyle}>{key}</kbd> {label}
+            </span>
+          ))}
+        </div>
+        <button onClick={() => setMode('preset')} style={btnSecondary}>
+          ✕ Exit Free Camera
+        </button>
+      </div>
+    );
+  }
+
+  // ── Default: preset navigation bar ──
+  return (
+    <div style={{
+      position: 'fixed', bottom: 20, left: '50%', transform: 'translateX(-50%)',
+      display: 'flex', gap: 8, alignItems: 'center',
+      zIndex: 9999, fontFamily: 'system-ui, sans-serif',
+      flexWrap: 'wrap', justifyContent: 'center', maxWidth: '95vw',
+    }}>
+      {CAMERA_PRESETS.map((p, i) => (
+        <button key={p.name} data-preset={i} style={btnPreset} title={`Go to: ${p.name}`}>
+          {p.name}
+        </button>
+      ))}
+      <div style={{ width: 1, height: 24, background: 'rgba(255,255,255,0.15)' }} />
+      <button onClick={() => setMode('confirming')} style={btnUnlock}>
+        🔓 Free Camera
+      </button>
+    </div>
+  );
+}

--- a/3D_portfolio/src/components/EmulatorV86.jsx
+++ b/3D_portfolio/src/components/EmulatorV86.jsx
@@ -50,7 +50,7 @@ export default function EmulatorV86() {
           autostart: true,
           bios: { url: "/v86/bios/seabios.bin" },
           vga_bios: { url: "/v86/bios/vgabios.bin" },
-          cdrom: { url: "/v86/images/tinycore.iso" }, // swap to your choice
+          cdrom: { url: "/v86/images/TinyCore-current.iso" },
           // boot_order: 0x132, // optional
         });
 

--- a/3D_portfolio/src/components/FreeCameraControls.jsx
+++ b/3D_portfolio/src/components/FreeCameraControls.jsx
@@ -1,29 +1,14 @@
 // src/components/FreeCameraControls.jsx
+// Three.js / R3F logic only — NO DOM rendering.
+// DOM HUD lives in CameraHUD.jsx, rendered outside <Canvas> in App.jsx.
 import { useThree, useFrame } from '@react-three/fiber';
 import { PointerLockControls } from '@react-three/drei';
-import { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// SPAWN POINT — camera starts here when the site loads.
-//
-// Room world bounds (from GLB): X 1.67–3.76  Y 3.19–4.19  Z 2.68–4.89
-// Monitors sit at Z ≈ 2.82.  Bed is at the far / high-Z end.
-//
-// POSITION: above-bed area, slightly elevated.
-// LOOK_AT:  toward the monitor cluster.
-//
-// To adjust: move in-game, then open browser console and type:
-//   window.__camera.position  → copy those values here
-// ─────────────────────────────────────────────────────────────────────────────
-const SPAWN_POSITION = new THREE.Vector3(2.7, 4.05, 4.6);
-const SPAWN_LOOK_AT  = new THREE.Vector3(2.9, 3.55, 2.85);
+export const SPAWN_POSITION = new THREE.Vector3(2.7, 4.05, 4.6);
+export const SPAWN_LOOK_AT  = new THREE.Vector3(2.9, 3.55, 2.85);
 
-// ─────────────────────────────────────────────────────────────────────────────
-// CAMERA PRESETS — the buttons users click.
-// Adjust positions once you've explored the room.
-// ─────────────────────────────────────────────────────────────────────────────
 export const CAMERA_PRESETS = [
   {
     name: 'Overview',
@@ -47,16 +32,11 @@ export const CAMERA_PRESETS = [
   },
 ];
 
-// Expose camera globally so users can find spawn coords in the console
 if (typeof window !== 'undefined') window.__cameraPresets = CAMERA_PRESETS;
 
-// ─────────────────────────────────────────────────────────────────────────────
+const _lookDir = new THREE.Matrix4();
 
-const _targetPos  = new THREE.Vector3();
-const _targetQuat = new THREE.Quaternion();
-const _lookDir    = new THREE.Matrix4();
-
-function quatFromLookAt(position, target) {
+export function quatFromLookAt(position, target) {
   _lookDir.lookAt(position, target, new THREE.Vector3(0, 1, 0));
   const q = new THREE.Quaternion();
   q.setFromRotationMatrix(_lookDir);
@@ -64,225 +44,65 @@ function quatFromLookAt(position, target) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// HUD — rendered via portal into document.body
+// Props:
+//   mode        — 'preset' | 'confirming' | 'free'  (owned by App)
+//   setMode     — setter from App
+//   plcLockRef  — ref whose .current will be set to () => plcRef.current.lock()
+//                 so CameraHUD can trigger pointer lock without being in Canvas
 // ─────────────────────────────────────────────────────────────────────────────
-function CameraHUD({ mode, onRequestFree, onConfirmFree, onCancelFree, onExitFree }) {
-  // ── Confirmation overlay ──
-  if (mode === 'confirming') {
-    return createPortal(
-      <div style={{
-        position: 'fixed', inset: 0,
-        background: 'rgba(0,0,0,0.75)',
-        backdropFilter: 'blur(4px)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        zIndex: 10000,
-      }}>
-        <div style={{
-          background: '#0f172a',
-          border: '1px solid rgba(255,255,255,0.15)',
-          borderRadius: 12,
-          padding: '28px 32px',
-          maxWidth: 380,
-          width: '90vw',
-          color: '#fff',
-          fontFamily: 'system-ui, sans-serif',
-          boxShadow: '0 25px 60px rgba(0,0,0,0.6)',
-        }}>
-          <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 8 }}>
-            🔓 Enable Free Camera?
-          </div>
-          <div style={{ fontSize: 13, color: '#94a3b8', lineHeight: 1.6, marginBottom: 20 }}>
-            This will lock your mouse cursor to the window for first-person exploration.
-          </div>
-          <div style={{
-            background: '#1e293b', borderRadius: 8, padding: '12px 16px',
-            marginBottom: 20, fontSize: 12, color: '#cbd5e1', lineHeight: 2,
-          }}>
-            <div><kbd style={kbdStyle}>W A S D</kbd> &nbsp;Move</div>
-            <div><kbd style={kbdStyle}>Mouse</kbd> &nbsp;Look around</div>
-            <div><kbd style={kbdStyle}>Space</kbd> / <kbd style={kbdStyle}>Ctrl</kbd> &nbsp;Up / Down</div>
-            <div><kbd style={kbdStyle}>Shift</kbd> &nbsp;Sprint</div>
-            <div><kbd style={kbdStyle}>Esc</kbd> &nbsp;Exit free camera</div>
-          </div>
-          <div style={{ display: 'flex', gap: 10 }}>
-            <button onClick={onCancelFree} style={btnSecondary}>Cancel</button>
-            <button onClick={onConfirmFree} style={btnPrimary}>Enter Free Camera</button>
-          </div>
-        </div>
-      </div>,
-      document.body
-    );
-  }
-
-  // ── Free camera mode — persistent tutorial banner + exit button ──
-  if (mode === 'free') {
-    return createPortal(
-      <div style={{
-        position: 'fixed', bottom: 0, left: 0, right: 0,
-        background: 'rgba(0,0,0,0.7)',
-        backdropFilter: 'blur(8px)',
-        borderTop: '1px solid rgba(255,255,255,0.1)',
-        padding: '8px 16px',
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        zIndex: 9999, fontFamily: 'system-ui, sans-serif',
-        flexWrap: 'wrap', gap: 8,
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
-          <span style={{ color: '#64748b', fontSize: 11 }}>FREE CAMERA</span>
-          {[
-            ['W A S D', 'Move'],
-            ['Mouse', 'Look'],
-            ['Space / Ctrl', 'Up / Down'],
-            ['Shift', 'Sprint'],
-            ['Esc', 'Exit'],
-          ].map(([key, label]) => (
-            <span key={key} style={{ fontSize: 11, color: '#94a3b8' }}>
-              <kbd style={kbdStyle}>{key}</kbd> {label}
-            </span>
-          ))}
-        </div>
-        <button onClick={onExitFree} style={btnSecondary}>
-          ✕ Exit Free Camera
-        </button>
-      </div>,
-      document.body
-    );
-  }
-
-  // ── Default preset mode — navigation buttons ──
-  return createPortal(
-    <div style={{
-      position: 'fixed', bottom: 20, left: '50%',
-      transform: 'translateX(-50%)',
-      display: 'flex', gap: 8, alignItems: 'center',
-      zIndex: 9999, fontFamily: 'system-ui, sans-serif',
-      flexWrap: 'wrap', justifyContent: 'center',
-      maxWidth: '95vw',
-    }}>
-      {/* Preset buttons */}
-      {CAMERA_PRESETS.map((p, i) => (
-        <button
-          key={p.name}
-          data-preset={i}
-          style={{
-            ...btnPreset,
-            // Active state via dataset (set in useFrame below)
-          }}
-          title={`Go to: ${p.name}`}
-        >
-          {p.name}
-        </button>
-      ))}
-
-      {/* Divider */}
-      <div style={{ width: 1, height: 24, background: 'rgba(255,255,255,0.15)' }} />
-
-      {/* Free camera unlock */}
-      <button onClick={onRequestFree} style={btnUnlock}>
-        🔓 Free Camera
-      </button>
-    </div>,
-    document.body
-  );
-}
-
-// ── Inline styles ──────────────────────────────────────────────────────────
-const kbdStyle = {
-  background: '#1e293b', border: '1px solid #334155',
-  borderRadius: 4, padding: '1px 6px', fontSize: 11,
-  fontFamily: 'monospace', color: '#e2e8f0',
-};
-const btnBase = {
-  border: 'none', cursor: 'pointer', borderRadius: 8,
-  fontFamily: 'system-ui, sans-serif', fontWeight: 500,
-  transition: 'all 0.15s',
-};
-const btnPrimary = {
-  ...btnBase, flex: 1,
-  background: '#3b82f6', color: '#fff',
-  padding: '9px 16px', fontSize: 13,
-};
-const btnSecondary = {
-  ...btnBase,
-  background: 'rgba(255,255,255,0.08)',
-  color: '#94a3b8',
-  border: '1px solid rgba(255,255,255,0.12)',
-  padding: '7px 14px', fontSize: 12,
-};
-const btnPreset = {
-  ...btnBase,
-  background: 'rgba(15,23,42,0.85)',
-  color: '#e2e8f0',
-  border: '1px solid rgba(255,255,255,0.15)',
-  backdropFilter: 'blur(8px)',
-  padding: '8px 16px', fontSize: 12,
-};
-const btnUnlock = {
-  ...btnBase,
-  background: 'rgba(59,130,246,0.15)',
-  color: '#93c5fd',
-  border: '1px solid rgba(59,130,246,0.3)',
-  backdropFilter: 'blur(8px)',
-  padding: '8px 16px', fontSize: 12,
-};
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Main component
-// ─────────────────────────────────────────────────────────────────────────────
-export default function FreeCameraControls() {
+export default function FreeCameraControls({ mode, setMode, plcLockRef }) {
   const { camera } = useThree();
-  const [mode, setMode] = useState('preset'); // 'preset' | 'confirming' | 'free'
   const plcRef = useRef();
 
-  const presetTarget = useRef(null);  // { position, quaternion }
+  const presetTarget = useRef(null);
   const lerpingRef   = useRef(false);
-  const activePreset = useRef(0);
 
-  const keys = useRef({});
+  const keys      = useRef({});
   const direction = useRef(new THREE.Vector3());
 
-  // ── Expose camera globally for coordinate discovery ─────────────────────
-  useEffect(() => {
-    window.__camera = camera;
-  }, [camera]);
+  // Expose camera globally for coordinate discovery
+  useEffect(() => { window.__camera = camera; }, [camera]);
 
-  // ── Set spawn point and rotation order ──────────────────────────────────
+  // Expose pointer-lock trigger to CameraHUD (outside Canvas)
+  useEffect(() => {
+    if (plcLockRef) plcLockRef.current = () => plcRef.current?.lock?.();
+  }, [plcLockRef]);
+
+  // Spawn position + rotation order
   useEffect(() => {
     camera.rotation.order = 'YXZ';
     camera.position.copy(SPAWN_POSITION);
     camera.quaternion.copy(quatFromLookAt(SPAWN_POSITION, SPAWN_LOOK_AT));
   }, [camera]);
 
-  // ── Wire preset buttons (event delegation on the HUD) ───────────────────
+  // Unlock pointer when leaving free mode
+  useEffect(() => {
+    if (mode !== 'free') plcRef.current?.unlock?.();
+  }, [mode]);
+
+  // Preset button delegation — CameraHUD buttons carry data-preset attribute
   useEffect(() => {
     const handler = (e) => {
       const btn = e.target.closest('[data-preset]');
       if (!btn) return;
-      const idx = parseInt(btn.dataset.preset, 10);
-      goToPreset(idx);
+      goToPreset(parseInt(btn.dataset.preset, 10));
     };
     document.addEventListener('click', handler);
     return () => document.removeEventListener('click', handler);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Keyboard ─────────────────────────────────────────────────────────────
+  // Keyboard
   useEffect(() => {
-    const dn = (e) => {
-      keys.current[e.code] = true;
-      if (e.code === 'Escape' && mode === 'free') {
-        exitFree();
-      }
-    };
+    const dn = (e) => { keys.current[e.code] = true; };
     const up = (e) => { keys.current[e.code] = false; };
     window.addEventListener('keydown', dn);
-    window.addEventListener('keyup', up);
+    window.addEventListener('keyup',   up);
     return () => {
       window.removeEventListener('keydown', dn);
-      window.removeEventListener('keyup', up);
+      window.removeEventListener('keyup',   up);
     };
-  }, [mode]);
+  }, []);
 
-  // ── Mode transitions ──────────────────────────────────────────────────────
   const goToPreset = (idx) => {
     const p = CAMERA_PRESETS[idx];
     if (!p) return;
@@ -291,27 +111,10 @@ export default function FreeCameraControls() {
       quaternion: quatFromLookAt(p.position, p.lookAt),
     };
     lerpingRef.current = true;
-    activePreset.current = idx;
   };
 
-  const requestFree  = () => setMode('confirming');
-  const cancelFree   = () => setMode('preset');
-
-  const confirmFree  = () => {
-    setMode('free');
-    // Small delay so the confirm button click doesn't interfere with pointer lock
-    setTimeout(() => plcRef.current?.lock?.(), 150);
-  };
-
-  const exitFree = () => {
-    plcRef.current?.unlock?.();
-    setMode('preset');
-  };
-
-  // ── Per-frame ─────────────────────────────────────────────────────────────
   useFrame((_, delta) => {
     if (mode === 'free') {
-      // ── Free camera WASD ──
       const speed = keys.current['ShiftLeft'] ? 15 : 5;
       direction.current.set(0, 0, 0);
       if (keys.current['KeyW']) direction.current.z += 1;
@@ -331,7 +134,6 @@ export default function FreeCameraControls() {
       return;
     }
 
-    // ── Preset lerp (preset mode) ──
     if (lerpingRef.current && presetTarget.current) {
       const t = Math.min(delta * 5, 1);
       camera.position.lerp(presetTarget.current.position, t);
@@ -344,21 +146,7 @@ export default function FreeCameraControls() {
     }
   });
 
-  return (
-    <>
-      {mode === 'free' && (
-        <PointerLockControls
-          ref={plcRef}
-          onUnlock={exitFree}
-        />
-      )}
-      <CameraHUD
-        mode={mode}
-        onRequestFree={requestFree}
-        onConfirmFree={confirmFree}
-        onCancelFree={cancelFree}
-        onExitFree={exitFree}
-      />
-    </>
-  );
+  return mode === 'free' ? (
+    <PointerLockControls ref={plcRef} onUnlock={() => setMode('preset')} />
+  ) : null;
 }

--- a/3D_portfolio/src/components/MobileControls.jsx
+++ b/3D_portfolio/src/components/MobileControls.jsx
@@ -1,140 +1,51 @@
 // src/components/MobileControls.jsx
-//
-// Mobile touch controls — only active on touch devices (zero overhead on desktop).
-//
-// Default mode  — same as desktop: preset buttons shown, free camera is opt-in.
-// Free mode     — virtual joystick (left) + drag to look (right) + exit button.
-// Preset mode   — tap a named button to smoothly lerp to that viewpoint.
-
-import { createPortal } from 'react-dom';
+// Three.js / R3F logic only — NO DOM rendering.
+// DOM overlay lives in MobileHUD.jsx, rendered outside <Canvas> in App.jsx.
 import { useThree, useFrame } from '@react-three/fiber';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import * as THREE from 'three';
-import { CAMERA_PRESETS } from './FreeCameraControls';
+import { quatFromLookAt, CAMERA_PRESETS } from './FreeCameraControls';
 
-const IS_TOUCH = typeof window !== 'undefined' &&
+export const IS_TOUCH = typeof window !== 'undefined' &&
   ('ontouchstart' in window || navigator.maxTouchPoints > 0);
 
-const JOYSTICK_R   = 48;
-const KNOB_R       = 20;
-const MOVE_SPEED   = 5;
-const LOOK_SENS    = 0.003;
-const PITCH_LIMIT  = Math.PI / 2 - 0.05;
+// ── Shared module-level state — written by MobileHUD, read by useFrame ───────
+export const move = { x: 0, y: 0 };
+export const look = { dx: 0, dy: 0 };
 
-// Shared touch state — written by DOM handlers, read by useFrame
-const move  = { x: 0, y: 0 };
-const look  = { dx: 0, dy: 0 };
-
-// ── lookAt-based quaternion (same helper as FreeCameraControls) ──────────────
-const _lm = new THREE.Matrix4();
-function quatFromLookAt(position, target) {
-  _lm.lookAt(position, target, new THREE.Vector3(0, 1, 0));
-  const q = new THREE.Quaternion();
-  q.setFromRotationMatrix(_lm);
-  return q;
-}
+// Preset-lerp state — written by MobileHUD.goToPreset, read by useFrame
+export const mobilePreset = {
+  target:  null,
+  lerping: false,
+  quat:    new THREE.Quaternion(),
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
-function MobileControlsInner() {
+// Props:
+//   mode    — 'preset' | 'confirming' | 'free'
+//   setMode — setter from App
+// ─────────────────────────────────────────────────────────────────────────────
+export default function MobileControls({ mode }) {
   const { camera } = useThree();
-  const [mode, setMode] = useState('preset'); // 'preset' | 'confirming' | 'free'
-
-  const joystickBaseRef = useRef(null);
-  const joystickKnobRef = useRef(null);
-
-  const presetTarget  = useRef(null);
-  const lerpingRef    = useRef(false);
-  const _targetQuat   = useRef(new THREE.Quaternion());
 
   useEffect(() => { camera.rotation.order = 'YXZ'; }, [camera]);
 
-  // ── Touch handlers (only in free mode) ───────────────────────────────────
-  useEffect(() => {
-    if (!IS_TOUCH || mode !== 'free') return;
+  const LOOK_SENS   = 0.003;
+  const PITCH_LIMIT = Math.PI / 2 - 0.05;
+  const MOVE_SPEED  = 5;
 
-    let joystickId = null, joystickOrigin = { x: 0, y: 0 };
-    let lookId = null, lastLook = { x: 0, y: 0 };
-
-    const onStart = (e) => {
-      for (const t of e.changedTouches) {
-        const left = t.clientX < window.innerWidth / 2;
-        if (left && joystickId === null) {
-          joystickId = t.identifier;
-          joystickOrigin = { x: t.clientX, y: t.clientY };
-          if (joystickBaseRef.current) {
-            joystickBaseRef.current.style.left = `${t.clientX - JOYSTICK_R}px`;
-            joystickBaseRef.current.style.top  = `${t.clientY - JOYSTICK_R}px`;
-            joystickBaseRef.current.style.opacity = '0.75';
-          }
-        } else if (!left && lookId === null) {
-          lookId = t.identifier;
-          lastLook = { x: t.clientX, y: t.clientY };
-        }
-      }
-    };
-
-    const onMove = (e) => {
-      for (const t of e.changedTouches) {
-        if (t.identifier === joystickId) {
-          const dx = t.clientX - joystickOrigin.x;
-          const dy = t.clientY - joystickOrigin.y;
-          const dist = Math.min(Math.hypot(dx, dy), JOYSTICK_R);
-          const angle = Math.atan2(dy, dx);
-          move.x = (dist / JOYSTICK_R) * Math.cos(angle);
-          move.y = (dist / JOYSTICK_R) * Math.sin(angle);
-          if (joystickKnobRef.current) {
-            joystickKnobRef.current.style.transform =
-              `translate(${move.x * JOYSTICK_R}px,${move.y * JOYSTICK_R}px)`;
-          }
-        } else if (t.identifier === lookId) {
-          look.dx += t.clientX - lastLook.x;
-          look.dy += t.clientY - lastLook.y;
-          lastLook = { x: t.clientX, y: t.clientY };
-        }
-      }
-    };
-
-    const onEnd = (e) => {
-      for (const t of e.changedTouches) {
-        if (t.identifier === joystickId) {
-          joystickId = null;
-          move.x = 0; move.y = 0;
-          if (joystickKnobRef.current)
-            joystickKnobRef.current.style.transform = 'translate(0px,0px)';
-          if (joystickBaseRef.current)
-            joystickBaseRef.current.style.opacity = '0.35';
-        } else if (t.identifier === lookId) {
-          lookId = null;
-        }
-      }
-    };
-
-    window.addEventListener('touchstart',  onStart, { passive: true });
-    window.addEventListener('touchmove',   onMove,  { passive: true });
-    window.addEventListener('touchend',    onEnd,   { passive: true });
-    window.addEventListener('touchcancel', onEnd,   { passive: true });
-    return () => {
-      window.removeEventListener('touchstart',  onStart);
-      window.removeEventListener('touchmove',   onMove);
-      window.removeEventListener('touchend',    onEnd);
-      window.removeEventListener('touchcancel', onEnd);
-      move.x = 0; move.y = 0; look.dx = 0; look.dy = 0;
-    };
-  }, [mode]);
-
-  // ── Per-frame camera update ───────────────────────────────────────────────
   useFrame((_, delta) => {
     if (!IS_TOUCH) return;
 
     // Preset lerp
-    if (lerpingRef.current && presetTarget.current) {
+    if (mobilePreset.lerping && mobilePreset.target) {
       const t = Math.min(delta * 5, 1);
-      camera.position.lerp(presetTarget.current.position, t);
-      camera.quaternion.slerp(_targetQuat.current, t);
-      if (camera.position.distanceTo(presetTarget.current.position) < 0.005) {
-        camera.position.copy(presetTarget.current.position);
-        camera.quaternion.copy(_targetQuat.current);
-        lerpingRef.current = false;
+      camera.position.lerp(mobilePreset.target, t);
+      camera.quaternion.slerp(mobilePreset.quat, t);
+      if (camera.position.distanceTo(mobilePreset.target) < 0.005) {
+        camera.position.copy(mobilePreset.target);
+        camera.quaternion.copy(mobilePreset.quat);
+        mobilePreset.lerping = false;
       }
       return;
     }
@@ -159,137 +70,5 @@ function MobileControlsInner() {
     }
   });
 
-  if (!IS_TOUCH) return null;
-
-  const goToPreset = (idx) => {
-    const p = CAMERA_PRESETS[idx];
-    if (!p) return;
-    presetTarget.current = { position: p.position.clone() };
-    _targetQuat.current  = quatFromLookAt(p.position, p.lookAt);
-    lerpingRef.current   = true;
-    if (mode === 'free') setMode('preset');
-  };
-
-  const enterFree = () => setMode('free');
-  const exitFree  = () => { setMode('preset'); move.x = 0; move.y = 0; };
-
-  // ── DOM overlay ───────────────────────────────────────────────────────────
-
-  // Confirmation screen
-  if (mode === 'confirming') {
-    return createPortal(
-      <div style={{
-        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.8)',
-        backdropFilter: 'blur(4px)', display: 'flex',
-        alignItems: 'center', justifyContent: 'center', zIndex: 10001,
-        fontFamily: 'system-ui, sans-serif',
-      }}>
-        <div style={{
-          background: '#0f172a', border: '1px solid rgba(255,255,255,0.15)',
-          borderRadius: 12, padding: '24px', maxWidth: 320, width: '88vw', color: '#fff',
-        }}>
-          <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>🔓 Free Camera?</div>
-          <div style={{ fontSize: 12, color: '#94a3b8', marginBottom: 16, lineHeight: 1.6 }}>
-            Left half of screen → joystick to move<br />
-            Right half → drag to look around<br />
-            Tap "Exit" to return to normal navigation.
-          </div>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button onClick={() => setMode('preset')} style={mBtn('#1e293b', '#94a3b8')}>Cancel</button>
-            <button onClick={enterFree}               style={mBtn('#3b82f6', '#fff')}>Enter</button>
-          </div>
-        </div>
-      </div>,
-      document.body
-    );
-  }
-
-  // Free camera overlay
-  if (mode === 'free') {
-    return createPortal(
-      <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 9998 }}>
-        {/* Joystick */}
-        <div ref={joystickBaseRef} style={{
-          position: 'absolute', bottom: 60, left: 40,
-          width: JOYSTICK_R * 2, height: JOYSTICK_R * 2,
-          borderRadius: '50%', opacity: 0.35, pointerEvents: 'none',
-          background: 'rgba(255,255,255,0.12)',
-          border: '2px solid rgba(255,255,255,0.35)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-        }}>
-          <div ref={joystickKnobRef} style={{
-            width: KNOB_R * 2, height: KNOB_R * 2, borderRadius: '50%',
-            background: 'rgba(255,255,255,0.55)', pointerEvents: 'none',
-          }} />
-        </div>
-
-        {/* Look hint */}
-        <div style={{
-          position: 'absolute', bottom: 60, right: 40,
-          width: 88, height: 88, borderRadius: '50%',
-          border: '2px dashed rgba(255,255,255,0.2)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          opacity: 0.4, pointerEvents: 'none',
-        }}>
-          <span style={{ color: '#fff', fontSize: 10, textAlign: 'center', lineHeight: 1.4 }}>drag<br/>to look</span>
-        </div>
-
-        {/* Exit button */}
-        <button
-          onTouchStart={(e) => { e.stopPropagation(); exitFree(); }}
-          style={{
-            position: 'absolute', top: 16, right: 16,
-            pointerEvents: 'all',
-            background: 'rgba(239,68,68,0.2)', color: '#fca5a5',
-            border: '1px solid rgba(239,68,68,0.4)',
-            borderRadius: 8, padding: '8px 14px', fontSize: 12,
-            fontFamily: 'system-ui, sans-serif',
-          }}
-        >
-          ✕ Exit Free Camera
-        </button>
-      </div>,
-      document.body
-    );
-  }
-
-  // Preset mode — navigation buttons
-  return createPortal(
-    <div style={{
-      position: 'fixed', bottom: 20, left: '50%', transform: 'translateX(-50%)',
-      display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center',
-      zIndex: 9999, maxWidth: '95vw',
-    }}>
-      {CAMERA_PRESETS.map((p, i) => (
-        <button
-          key={p.name}
-          onTouchStart={(e) => { e.preventDefault(); goToPreset(i); }}
-          style={mBtn('#0f172acc', '#e2e8f0', '1px solid rgba(255,255,255,0.15)')}
-        >
-          {p.name}
-        </button>
-      ))}
-      <button
-        onTouchStart={(e) => { e.preventDefault(); setMode('confirming'); }}
-        style={mBtn('rgba(59,130,246,0.15)', '#93c5fd', '1px solid rgba(59,130,246,0.3)')}
-      >
-        🔓 Free Camera
-      </button>
-    </div>,
-    document.body
-  );
-}
-
-function mBtn(bg, color, border = 'none') {
-  return {
-    background: bg, color, border,
-    borderRadius: 8, padding: '8px 16px', fontSize: 12,
-    fontFamily: 'system-ui, sans-serif',
-    cursor: 'pointer', backdropFilter: 'blur(8px)',
-    WebkitBackdropFilter: 'blur(8px)',
-  };
-}
-
-export default function MobileControls() {
-  return <MobileControlsInner />;
+  return null;
 }

--- a/3D_portfolio/src/components/MobileHUD.jsx
+++ b/3D_portfolio/src/components/MobileHUD.jsx
@@ -1,0 +1,219 @@
+// src/components/MobileHUD.jsx
+// Mobile touch overlay — rendered OUTSIDE <Canvas> in App.jsx.
+// Writes to module-level move/look/mobilePreset shared with MobileControls.jsx.
+import { useEffect, useRef } from 'react';
+import { IS_TOUCH, move, look, mobilePreset } from './MobileControls';
+import { quatFromLookAt, CAMERA_PRESETS } from './FreeCameraControls';
+import * as THREE from 'three';
+
+const JOYSTICK_R  = 48;
+const KNOB_R      = 20;
+
+function mBtn(bg, color, border = 'none') {
+  return {
+    background: bg, color, border,
+    borderRadius: 8, padding: '8px 16px', fontSize: 12,
+    fontFamily: 'system-ui, sans-serif',
+    cursor: 'pointer', backdropFilter: 'blur(8px)',
+    WebkitBackdropFilter: 'blur(8px)',
+  };
+}
+
+const goToPreset = (idx) => {
+  const p = CAMERA_PRESETS[idx];
+  if (!p) return;
+  mobilePreset.target  = p.position.clone();
+  mobilePreset.quat    = quatFromLookAt(p.position, p.lookAt);
+  mobilePreset.lerping = true;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Props:
+//   mode    — 'preset' | 'confirming' | 'free'
+//   setMode — setter from App
+// ─────────────────────────────────────────────────────────────────────────────
+export default function MobileHUD({ mode, setMode }) {
+  const joystickBaseRef = useRef(null);
+  const joystickKnobRef = useRef(null);
+
+  // Touch handlers — only active in free mode
+  useEffect(() => {
+    if (!IS_TOUCH || mode !== 'free') return;
+
+    let joystickId = null, joystickOrigin = { x: 0, y: 0 };
+    let lookId = null, lastLook = { x: 0, y: 0 };
+
+    const onStart = (e) => {
+      for (const t of e.changedTouches) {
+        const left = t.clientX < window.innerWidth / 2;
+        if (left && joystickId === null) {
+          joystickId = t.identifier;
+          joystickOrigin = { x: t.clientX, y: t.clientY };
+          if (joystickBaseRef.current) {
+            joystickBaseRef.current.style.left    = `${t.clientX - JOYSTICK_R}px`;
+            joystickBaseRef.current.style.top     = `${t.clientY - JOYSTICK_R}px`;
+            joystickBaseRef.current.style.opacity = '0.75';
+          }
+        } else if (!left && lookId === null) {
+          lookId = t.identifier;
+          lastLook = { x: t.clientX, y: t.clientY };
+        }
+      }
+    };
+
+    const onMove = (e) => {
+      for (const t of e.changedTouches) {
+        if (t.identifier === joystickId) {
+          const dx    = t.clientX - joystickOrigin.x;
+          const dy    = t.clientY - joystickOrigin.y;
+          const dist  = Math.min(Math.hypot(dx, dy), JOYSTICK_R);
+          const angle = Math.atan2(dy, dx);
+          move.x = (dist / JOYSTICK_R) * Math.cos(angle);
+          move.y = (dist / JOYSTICK_R) * Math.sin(angle);
+          if (joystickKnobRef.current) {
+            joystickKnobRef.current.style.transform =
+              `translate(${move.x * JOYSTICK_R}px,${move.y * JOYSTICK_R}px)`;
+          }
+        } else if (t.identifier === lookId) {
+          look.dx += t.clientX - lastLook.x;
+          look.dy += t.clientY - lastLook.y;
+          lastLook = { x: t.clientX, y: t.clientY };
+        }
+      }
+    };
+
+    const onEnd = (e) => {
+      for (const t of e.changedTouches) {
+        if (t.identifier === joystickId) {
+          joystickId = null;
+          move.x = 0; move.y = 0;
+          if (joystickKnobRef.current)
+            joystickKnobRef.current.style.transform = 'translate(0px,0px)';
+          if (joystickBaseRef.current)
+            joystickBaseRef.current.style.opacity = '0.35';
+        } else if (t.identifier === lookId) {
+          lookId = null;
+        }
+      }
+    };
+
+    window.addEventListener('touchstart',  onStart, { passive: true });
+    window.addEventListener('touchmove',   onMove,  { passive: true });
+    window.addEventListener('touchend',    onEnd,   { passive: true });
+    window.addEventListener('touchcancel', onEnd,   { passive: true });
+    return () => {
+      window.removeEventListener('touchstart',  onStart);
+      window.removeEventListener('touchmove',   onMove);
+      window.removeEventListener('touchend',    onEnd);
+      window.removeEventListener('touchcancel', onEnd);
+      move.x = 0; move.y = 0; look.dx = 0; look.dy = 0;
+    };
+  }, [mode]);
+
+  if (!IS_TOUCH) return null;
+
+  const exitFree = () => { setMode('preset'); move.x = 0; move.y = 0; };
+
+  // ── Confirmation screen ──
+  if (mode === 'confirming') {
+    return (
+      <div style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.8)',
+        backdropFilter: 'blur(4px)', display: 'flex',
+        alignItems: 'center', justifyContent: 'center', zIndex: 10001,
+        fontFamily: 'system-ui, sans-serif',
+      }}>
+        <div style={{
+          background: '#0f172a', border: '1px solid rgba(255,255,255,0.15)',
+          borderRadius: 12, padding: '24px', maxWidth: 320, width: '88vw', color: '#fff',
+        }}>
+          <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>🔓 Free Camera?</div>
+          <div style={{ fontSize: 12, color: '#94a3b8', marginBottom: 16, lineHeight: 1.6 }}>
+            Left half of screen → joystick to move<br />
+            Right half → drag to look around<br />
+            Tap "Exit" to return to normal navigation.
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={() => setMode('preset')} style={mBtn('#1e293b', '#94a3b8')}>Cancel</button>
+            <button onClick={() => setMode('free')}   style={mBtn('#3b82f6', '#fff')}>Enter</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Free camera overlay ──
+  if (mode === 'free') {
+    return (
+      <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 9998 }}>
+        {/* Joystick */}
+        <div ref={joystickBaseRef} style={{
+          position: 'absolute', bottom: 60, left: 40,
+          width: JOYSTICK_R * 2, height: JOYSTICK_R * 2,
+          borderRadius: '50%', opacity: 0.35, pointerEvents: 'none',
+          background: 'rgba(255,255,255,0.12)',
+          border: '2px solid rgba(255,255,255,0.35)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <div ref={joystickKnobRef} style={{
+            width: KNOB_R * 2, height: KNOB_R * 2, borderRadius: '50%',
+            background: 'rgba(255,255,255,0.55)', pointerEvents: 'none',
+          }} />
+        </div>
+
+        {/* Look hint */}
+        <div style={{
+          position: 'absolute', bottom: 60, right: 40,
+          width: 88, height: 88, borderRadius: '50%',
+          border: '2px dashed rgba(255,255,255,0.2)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          opacity: 0.4, pointerEvents: 'none',
+        }}>
+          <span style={{ color: '#fff', fontSize: 10, textAlign: 'center', lineHeight: 1.4 }}>
+            drag<br />to look
+          </span>
+        </div>
+
+        {/* Exit button */}
+        <button
+          onTouchStart={(e) => { e.stopPropagation(); exitFree(); }}
+          style={{
+            position: 'absolute', top: 16, right: 16,
+            pointerEvents: 'all',
+            background: 'rgba(239,68,68,0.2)', color: '#fca5a5',
+            border: '1px solid rgba(239,68,68,0.4)',
+            borderRadius: 8, padding: '8px 14px', fontSize: 12,
+            fontFamily: 'system-ui, sans-serif',
+          }}
+        >
+          ✕ Exit Free Camera
+        </button>
+      </div>
+    );
+  }
+
+  // ── Preset mode — navigation buttons ──
+  return (
+    <div style={{
+      position: 'fixed', bottom: 20, left: '50%', transform: 'translateX(-50%)',
+      display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center',
+      zIndex: 9999, maxWidth: '95vw',
+    }}>
+      {CAMERA_PRESETS.map((p, i) => (
+        <button
+          key={p.name}
+          onTouchStart={(e) => { e.preventDefault(); goToPreset(i); }}
+          style={mBtn('#0f172acc', '#e2e8f0', '1px solid rgba(255,255,255,0.15)')}
+        >
+          {p.name}
+        </button>
+      ))}
+      <button
+        onTouchStart={(e) => { e.preventDefault(); setMode('confirming'); }}
+        style={mBtn('rgba(59,130,246,0.15)', '#93c5fd', '1px solid rgba(59,130,246,0.3)')}
+      >
+        🔓 Free Camera
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
- Move CameraHUD and MobileHUD DOM rendering outside <Canvas> into App.jsx so R3F's reconciler never encounters <button>/<div> elements
- FreeCameraControls/MobileControls now return only Three.js primitives; camera state (mode/setMode/plcLockRef) owned by App and passed as props
- Fix 404: EmulatorV86 cdrom URL corrected to TinyCore-current.iso
- Add CLAUDE.md with architecture rules, especially the R3F DOM rendering constraint