### PR TITLE
Fix VTuber facing direction, monitor screen node names, switch AI to Groq

### DIFF
--- a/3D_portfolio/CLAUDE.md
+++ b/3D_portfolio/CLAUDE.md
@@ -66,8 +66,9 @@ _worldPos.set(CAM_OFFSET.x + floatX, CAM_OFFSET.y + floatY, CAM_OFFSET.z)
 group.position.copy(_worldPos);
 group.quaternion.copy(camera.quaternion);
 ```
-VRM0 faces +Z locally. When group quaternion = camera quaternion, local +Z = camera's +Z in world = BEHIND the camera = toward the viewer. ✓
-**Do NOT call `rotateVRM0`** for the camera-companion — it would make her face away.
+VRM0 models naturally face -Z. `rotateVRM0` flips them to face +Z.
+When group quaternion = camera quaternion, local +Z = camera's +Z in world = toward viewer. ✓
+**Always call `VRMUtils.rotateVRM0(vrm)`** before adding vrm.scene to the group.
 
 ## VTuber AI Chat
 - `api/chat.js` — Vercel serverless function, proxies to Claude Haiku. Set `ANTHROPIC_API_KEY` env var on Vercel.

--- a/3D_portfolio/api/chat.js
+++ b/3D_portfolio/api/chat.js
@@ -1,9 +1,9 @@
 // api/chat.js — Vercel serverless function
-// Proxies chat requests to Claude API, keeping the API key server-side.
-// Deploy to Vercel; set ANTHROPIC_API_KEY in project environment variables.
+// Uses Groq's free API (llama-3.1-8b-instant) — no cost for low usage.
+// Sign up at https://console.groq.com → API Keys → create key.
+// Set GROQ_API_KEY in Vercel project environment variables.
 
 export default async function handler(req, res) {
-  // CORS headers — allow the portfolio origin in production
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
@@ -16,39 +16,51 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'messages array required' });
   }
 
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    return res.status(200).json({
+      text: "Ahh, no API key yet — but hi!! Ask me anything once Timeshot sets it up~ (◕‿◕)✿",
+    });
+  }
+
   try {
-    const upstream = await fetch('https://api.anthropic.com/v1/messages', {
+    const upstream = await fetch('https://api.groq.com/openai/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-api-key': process.env.ANTHROPIC_API_KEY,
-        'anthropic-version': '2023-06-01',
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'claude-haiku-4-5',
-        max_tokens: 120,
-        system: [
-          "You are Yuki, an energetic and friendly VTuber AI companion in Timeshot's 3D portfolio.",
-          "Timeshot (Suhil Jugroop) is a developer skilled in React, Three.js, React Three Fiber, VRM models, Vite, and Tailwind.",
-          "Answer visitor questions about the portfolio, skills, and projects.",
-          "Keep ALL replies to 1–2 short sentences. Be warm, a little playful, and use the occasional kaomoji (e.g. (◕‿◕)✿). Never break character.",
-        ].join(' '),
-        messages,
+        model: 'llama-3.1-8b-instant',   // free tier, very fast
+        max_tokens: 100,
+        temperature: 0.8,
+        messages: [
+          {
+            role: 'system',
+            content: [
+              "You are Yuki, an energetic and friendly VTuber AI companion in Timeshot's 3D portfolio.",
+              "Timeshot (Suhil Jugroop) is a developer skilled in React, Three.js, React Three Fiber (R3F), VRM models, Vite, and Tailwind.",
+              "Answer visitor questions about the portfolio, skills, and projects.",
+              "Keep ALL replies to 1–2 short sentences. Be warm, a little playful, and use the occasional kaomoji (e.g. (◕‿◕)✿). Never break character.",
+            ].join(' '),
+          },
+          ...messages,
+        ],
       }),
     });
 
     if (!upstream.ok) {
       const err = await upstream.text();
-      console.error('Anthropic error:', err);
-      return res.status(upstream.status).json({ error: 'Upstream API error' });
+      console.error('Groq error:', err);
+      return res.status(200).json({ text: "Oops, something went wrong on my end (＞﹏＜) Try again!" });
     }
 
     const data = await upstream.json();
-    const text = data.content?.[0]?.text ?? '';
+    const text = data.choices?.[0]?.message?.content ?? '';
     return res.status(200).json({ text });
 
   } catch (err) {
     console.error('chat handler error:', err);
-    return res.status(500).json({ error: 'Internal server error' });
+    return res.status(200).json({ text: "Connection hiccup! (＞﹏＜) Try again in a sec~" });
   }
 }

--- a/3D_portfolio/src/components/VTuberChat.jsx
+++ b/3D_portfolio/src/components/VTuberChat.jsx
@@ -20,7 +20,7 @@ const C = {
 
 // Fallback greeting lines shown when the API is unavailable
 const FALLBACK_LINES = [
-  "Ahh, my API key isn't set yet — but hi!! (◕‿◕)✿",
+  "Oops, connection hiccup! (＞﹏＜) Try again~",
   "Welcome to Timeshot's portfolio! Ask me anything~",
   "I'm Yuki! Timeshot built me with React & Three.js (⌒‿⌒)",
 ];

--- a/3D_portfolio/src/components/VTuberView.jsx
+++ b/3D_portfolio/src/components/VTuberView.jsx
@@ -71,8 +71,10 @@ export default function VTuberView({ isSpeaking = false }) {
         const vrm = gltf.userData.vrm;
         VRMUtils.combineSkeletons?.(vrm.scene);
 
-        // VRM0 faces +Z — toward viewer in camera-relative mode. No rotation needed.
-        vrm.scene.rotation.set(0, 0, 0);
+        // rotateVRM0 rotates the model 180° on Y so it faces +Z (toward viewer).
+        // VRM0 models naturally face -Z; without this the character faces away.
+        // In camera-relative mode (+Z = toward viewer) this is exactly what we need.
+        VRMUtils.rotateVRM0?.(vrm);
 
         vrmRef.current = vrm;
         group.add(vrm.scene);

--- a/3D_portfolio/src/models/RoomScene.jsx
+++ b/3D_portfolio/src/models/RoomScene.jsx
@@ -14,9 +14,10 @@ import GitHubStats from "../components/GitHubStats";
 // GLB nodes may be Object3D groups, not Mesh — so we search by name only,
 // never filtering by isMesh. Box3.setFromObject works on any Object3D.
 // ─────────────────────────────────────────────────────────────────────────────
+// Node names as they appear in the GLB (underscores, not spaces)
 const SCREEN_MAP = {
-  "large monitor screen": "fakeOS",
-  "small monitor screen": "github",
+  "large_monitor_screen": "fakeOS",
+  "small_monitor_screen": "github",
 };
 
 // Find any Object3D by name — exact first, then case-insensitive.
@@ -84,6 +85,11 @@ export default function RoomScene() {
     if (result.length > 0) {
       computed.current = true;
       setScreenData(result);
+      // Expose screen centers for camera-preset coordinate discovery
+      window.__screenCenters = Object.fromEntries(
+        result.map(({ type, center }) => [type, center]),
+      );
+      console.info('[RoomScene] screen centers:', window.__screenCenters);
     }
   });
 


### PR DESCRIPTION
## Summary

Follow-up fixes after PR #11 was merged.

### VTuber facing direction
VRM0 models naturally face -Z. The previous commit removed , causing the character to face away from the viewer. Restored  which flips the model to +Z - the toward-viewer direction in camera-relative space (since  makes local +Z = camera back = viewer direction).

### Monitor screen node names
The GLB uses underscores, not spaces:  / . Previous  keys used spaces, silently failing the lookup. Also exposes  in dev console for camera-preset coordinate tuning.

### Groq free AI instead of Claude paid API
Switched  from Anthropic Claude to Groq  (free tier: 30 req/min, no credit card). Set  in Vercel env vars - get one free at https://console.groq.com. Graceful fallback message when key is absent.

## Deployment

1. Get a free Groq API key at https://console.groq.com
2. Vercel project → Settings → Environment Variables → add 

*Generated with Claude Code*