### PR TITLE
debug(vtuber): log post-mutation spring values to verify fix actually…

### DIFF
--- a/3D_portfolio/src/components/VTuberView.jsx
+++ b/3D_portfolio/src/components/VTuberView.jsx
@@ -148,7 +148,23 @@ export default function VTuberView({ isSpeaking = false, onReady, screenPosRef, 
               if (s.gravityPower !== undefined) s.gravityPower = Math.max(s.gravityPower, 0.3);
             }
           }
-          console.info(`[VTuber] spring joints: ${sbm.joints.size ?? sbm.joints.length ?? 'n/a'} | hair=${counts.hair} bust=${counts.bust} other=${counts.other}`, samples);
+          // Verify mutations actually stuck (some three-vrm versions wrap settings)
+          const verify = [];
+          let vi = 0;
+          for (const joint of sbm.joints) {
+            const s = joint.settings ?? joint;
+            const name = joint.bone?.name ?? '';
+            if (/hair/i.test(name) && verify.length < 2) {
+              verify.push({
+                bone: name,
+                stiffness: s.stiffness,
+                drag: s.dragForce,
+                gravityPower: s.gravityPower,
+              });
+            }
+            vi++;
+          }
+          console.info(`[VTuber] spring joints: ${sbm.joints.size ?? sbm.joints.length ?? 'n/a'} | hair=${counts.hair} chest=${counts.bust} other=${counts.other}`, { authored: samples, postFix: verify });
         } else {
           console.warn('[VTuber] no springBoneManager / no joints — hair physics unavailable');
         }


### PR DESCRIPTION
… applied

The previous diagnostic showed authored values (logged before mutation ran). This adds a second pass that re-reads the same joints AFTER the fix runs, so we can confirm gravityPower/dragForce actually stuck. If post-fix values still show gravityPower=0, the mutation isn't reaching the simulation and we need a different write path.